### PR TITLE
Syntax in a Nutshell - copy edits

### DIFF
--- a/SyntaxNutshell/SyntaxNutshell.pillar
+++ b/SyntaxNutshell/SyntaxNutshell.pillar
@@ -1,13 +1,12 @@
 !Syntax in a nutshell
 @chapterSyntaxNutshell
 
-Pharo adopts a syntax very close to that of its ancestor Smalltalk. The syntax
+Pharo adopts a syntax very close to that of its ancestor, Smalltalk. The syntax
 is designed so that program text can be read aloud as though it were a kind of
 pidgin English. The following method of the class ==Week== shows an example of
-the syntax. It checks whether ==DayNames== contains already the argument, i.e.,
-if this the argument represents a correct day name. When this is the case it
-will assigns it to the variable ==StartDay==.
-
+the syntax. It checks whether ==DayNames== already contains the argument, i.e.
+if this argument represents a correct day name. If this is the case, it
+will assign it to the variable ==StartDay==.
 
 [[[language=Smalltalk
 startDay: aSymbol
@@ -18,21 +17,24 @@ startDay: aSymbol
 ]]]
 
 Pharo's syntax is minimal. Essentially there is syntax only for sending messages
-(i.e., expressions). Expressions are built up from a very small number of
-primitive elements (message sends, assignments, closures, return...). There are
+(i.e. expressions). Expressions are built up from a very small number of
+primitive elements (message sends, assignments, closures, returns...). There are
 only 6 keywords, and there is no syntax for control structures or declaring new
 classes. Instead, nearly everything is achieved by sending messages to objects.
-For instance, instead of an if-then- else control structure,  conditionals are
-expressed as messages sent such as ==ifTrue:== to Boolean objects. New
+For instance, instead of an if-then-else control structure, conditionals are
+expressed as messages (such as ==ifTrue:==) sent to Boolean objects. New
 (sub-)classes are created by sending a message to their superclass.
 
 !! Syntactic elements
 
-Expressions are composed of the following building blocks: (i) six reserved
-keywords, or ''pseudo-variables'': ==self==, ==super==, ==nil==, ==true==,
-==false==, and ==thisContext==, (ii) constant expressions for ''literal''
-objects including numbers, characters, strings, symbols and arrays, (iii)
-variable declarations, (iv) assignments, (v) block closures, and (vi) messages.
+Expressions are composed of the following building blocks:
+
+# The six reserved keywords, or ''pseudo-variables'': ==self==, ==super==, ==nil==, ==true==, ==false==, and ==thisContext==
+# Constant expressions for ''literal'' objects including numbers, characters, strings, symbols and arrays
+# Variable declarations
+# Assignments
+# Block closures
+# Messages
 
 We can see examples of the various syntactic elements in the Table below.
 
@@ -61,7 +63,6 @@ We can see examples of the various syntactic elements in the Table below.
 |==Transcript show: 'hello' . Transcript cr==| expression separator (==.==)
 |==Transcript show: 'hello'; cr==| message cascade (==;==)
 
-
 ""Local variables."" ==startPoint== is a variable name, or identifier. By
 convention, identifiers are composed of words in "camelCase" (i.e., each word
 except the first starting with an upper case letter). The first letter of an
@@ -85,12 +86,13 @@ equal to decimal 5.
 ==2.4e7== is ==2.4 X 10^7==.
 
 ""Characters."" A dollar sign introduces a literal character: ==$a== is the
-literal for =='a'==. Instances of non-printing characters can be obtained by
-sending appropriately named messages to the ==Character== class, such as
-==Character space== and ==Character tab==.
+literal for the character =='a'==. Instances of non-printing characters can be
+obtained by sending appropriately named messages to the ==Character== class,
+such as ==Character space== and ==Character tab==.
 
 ""Strings."" Single quotes ==' '== are used to define a literal string. If you
-want a string with a quote inside, just double the quote, as in =='G''day'==.
+want a string with a single quote inside, just double the quote, as in
+=='G''day'==.
 
 ""Symbols."" are like Strings, in that they contain a sequence of characters.
 However, unlike a string, a literal symbol is guaranteed to be globally unique.
@@ -103,7 +105,7 @@ example, ==#(27 (true false) abc)== is a literal array of three elements: the
 integer 27, the compile-time array containing the two booleans, and the symbol
 ==#abc==. (Note that this is the same as ==#(27 #(true false) #abc)==.)
 
-""Run-time arrays."" Curly braces =={ }==  define a (dynamic) array at run-time.
+""Run-time arrays."" Curly braces =={ }== define a (dynamic) array at run-time.
 Elements are expressions separated by periods. So =={ 1. 2. 1 + 2 }== defines an
 array with elements 1, 2, and the result of evaluating ==1+2==.
 
@@ -121,15 +123,17 @@ function. As we shall see, blocks may take arguments (==[:i | ...]==) and can
 have local variables.
 
 ""Primitives."" ==< primitive: ... >== denotes an invocation of a virtual
-machine primitive. ( ==< primitive: 1 >== is the VM primitive for
-==SmallInteger== ) Any code following the primitive is executed only if the
-primitive fails. The same syntax is also used for method annotations.
+machine primitive. For example, ==< primitive: 1 >== is the VM primitive for
+==SmallInteger==. Any code following the primitive is executed only if the
+primitive fails. The same syntax is also used for method annotations (pragmas).
 
-""Unary messages."" They consist of a single word (like ==factorial==) sent to a
-receiver (like 3).
+""Unary messages."" These consist of a single word (like ==factorial==) sent to a
+receiver (like 3). In ==3 factorial==, 3 is the receiver, and ==factorial== is
+the message selector.
 
-""Binary messages."" They are operators for example ==+== sent to a receiver and
-taking a single argument. In ==3 + 4==, the receiver is 3 and the argument is 4.
+""Binary messages."" These are operators (for example: ==+==) sent to a
+receiver, and taking a single argument. In ==3 + 4==, the receiver is 3, the
+message selector is  ==+==, and the argument is 4.
 
 ""Keyword messages."" They consist of multiple keywords (like ==raisedTo:
 modulo:==), each ending with a colon and taking a single argument. In the
@@ -139,7 +143,7 @@ We send the message to the receiver 2.
 
 ""Method return."" ==^== is used to ''return'' a value from a method.
 
-""Sequences of statements."" A period or full-stop (.) is the statement
+""Sequences of statements."" A period or full-stop (==.==) is the statement
 separator. Putting a period between two expressions turns them into independent
 statements.
 
@@ -149,25 +153,25 @@ message ==show: 'hello'== to the receiver ==Transcript==, and then we send the
 unary message ==cr== to the same receiver.
 
 The classes ==Number==, ==Character==, ==String== and ==Boolean== are described
-in more detail in Chapter 8.
+in more detail in Chapter 8, ''Basic Classes''.
 
 !!Pseudo-variables
 
 In Pharo, there are 6 reserved keywords, or pseudo-variables: ==nil==, ==true==,
 ==false==, ==self==, ==super==, and ==thisContext==. They are called
 pseudo-variables because they are predefined and cannot be assigned to.
-==true==, ==false==, and ==nil== are constants while the values of ==self==,
+==true==, ==false==, and ==nil== are constants, while the values of ==self==,
 ==super==, and ==thisContext== vary dynamically as code is executed.
 
 - ==true== and ==false== are the unique instances of the Boolean classes ==True== and ==False==. See Chapter 8 for more details.
 
 - ==self== always refers to the receiver of the currently executing method.
 
-- ==super== also refers to the receiver of the current method, but when you send a message to ==super==, the method-lookup changes so that it starts from the superclass of the class containing the method that uses ==super==. For further details see Chapter 5.
+- ==super== also refers to the receiver of the current method, but when you send a message to ==super==, the method-lookup changes so that it starts from the superclass of the class containing the method that uses ==super==. For further details see Chapter 5, ''The Smalltalk Object Model''.
 
 - ==nil== is the undefined object. It is the unique instance of the class ==UndefinedObject==. Instance variables, class variables and local variables are initialized to ==nil==.
 
-- ==thisContext== is a pseudo-variable that represents the top frame of the execution stack. ==thisContext== is normally not of interest to most programmers, but it is essential for implementing development tools like the debugger and it is also used to implement exception handling and continuations.
+- ==thisContext== is a pseudo-variable that represents the top frame of the execution stack. ==thisContext== is normally not of interest to most programmers, but it is essential for implementing development tools like the debugger, and it is also used to implement exception handling and continuations.
 
 !!Message sends
 
@@ -195,11 +199,11 @@ keyword messages, so:
 [[[language=Smalltalk
 2 raisedTo: 1 + 3 factorial --> 128]]]
 
-(First we send factorial to 3, then we send \+ 6 to 1, and finally we send
-raisedTo: 7 to 2.) Recall that we use the notation expression \-\-\> result to
-show the result of evaluating an expression.
+(First we send ==factorial== to 3, then we send ==+ 6== to 1, and finally we
+send ==raisedTo: 7== to 2.) Recall that we use the notation expression ==- ->==
+to show the result of evaluating an expression.
 
-Precedence aside, evaluation is strictly from left to right, so
+Precedence aside, evaluation is strictly from left to right, so:
 
 [[[language=Smalltalk
 1 + 2 * 3 --> 9 ]]]
@@ -244,13 +248,14 @@ Programs are developed one method at a time, in the context of a given class. (A
 class is defined by sending a message to an existing class, asking it to create
 a subclass, so there is no special syntax required for defining classes.)
 
-Here is the method lineCount in the class String. (The usual convention is to
-refer to methods as ClassName\>\>methodName, so we call this method
+Here is the method ==lineCount== in the class ==String==. (The usual convention
+is to refer to methods as ClassName\>\>methodName, so we call this method
 String\>\>lineCount.)
 
 [[[language=Smalltalk
 String >> lineCount
 	"Answer the number of lines represented by the receiver, where every cr adds one line."
+
 	| cr count |
 	cr := Character cr.
 	count := 1 min: self size.
@@ -260,15 +265,15 @@ String >> lineCount
 
 Syntactically, a method consists of:
 
-#the method pattern, containing the name (i.e., ==lineCount==) and any arguments (none in this example);
-#comments (these may occur anywhere, but the convention is to put one at the top that explains what the method does);
+#the method pattern, containing the name (i.e., ==lineCount==) and any arguments (none in this example)
+#comments (these may occur anywhere, but the convention is to put one at the top that explains what the method does)
 #declarations of local variables (i.e., ==cr== and ==count==); and
-#any number of expressions separated by dots; here there are four.
+#any number of expressions separated by dots (here there are four)
 
-The evaluation of any expression preceded by a ^ (typed as upper arrow which is
-shift \+ 6 for most keyboards) will cause the method to exit at that point,
-returning the value of that expression. A method that terminates without
-explicitly returning some expression will implicitly return self.
+The evaluation of any expression preceded by a ==^== (a caret or upper
+arrow, which is Shift-6 for most keyboards) will cause the method to exit at
+that point, returning the value of that expression. A method that terminates
+without explicitly returning some expression will implicitly return ==self==.
 
 Arguments and local variables should always start with lower case letters. Names
 starting with upper-case letters are assumed to be global variables. Class
@@ -279,9 +284,9 @@ the object representing that class.
 
 Blocks provide a mechanism to defer the evaluation of expressions. A block is
 essentially an anonymous function. A block is evaluated by sending it the
-message value. The block answers the value of the last expression in its body,
-unless there is an explicit return (with ^), in which case it does not answer
-any value.
+message ==value==. The block answers the value of the last expression in its
+body, unless there is an explicit return (with ^), in which case it does not
+answer any value.
 
 [[[language=Smalltalk
 [ 1 + 2 ] value --> 3]]]
@@ -308,7 +313,7 @@ arguments:
 [ :x :y || z | z := x + y. z ] value: 1 value: 2 --> 3]]]
 
 Blocks are actually lexical closures, since they can refer to variables of the
-surrounding environment. The following block refers to the variable x of its
+surrounding environment. The following block refers to the variable ==x== of its
 enclosing environment:
 
 [[[language=Smalltalk
@@ -328,12 +333,13 @@ with blocks as arguments.
 
 Conditionals are expressed by sending one of the messages ==ifTrue:==,
 ==ifFalse:== or ==ifTrue:ifFalse:== to the result of a boolean expression. See
-Chapter 8 for more about booleans.
+Chapter 8, ''Basic Classes'', for more about booleans.
 
 [[[language=Smalltalk
 (17 * 13 > 220)
 	ifTrue: [ 'bigger' ]
-	ifFalse: [ 'smaller' ] -->'bigger']]]
+	ifFalse: [ 'smaller' ] -->'bigger'
+]]]
 
 Loops are typically expressed by sending messages to blocks, integers or
 collections. Since the exit condition for a loop may be repeatedly evaluated, it
@@ -343,21 +349,24 @@ procedural loop:
 [[[language=Smalltalk
 n := 1.
 [ n < 1000 ] whileTrue: [ n := n*2 ].
-n --> 1024]]]
+n --> 1024
+]]]
 
- ==whileFalse:== reverses the exit condition.
+==whileFalse:== reverses the exit condition.
 
 [[[language=Smalltalk
 n := 1.
 [ n > 1000 ] whileFalse: [ n := n*2 ].
-n --> 1024]]]
+n --> 1024
+]]]
 
- ==timesRepeat:== offers a simple way to implement a fixed iteration:
+==timesRepeat:== offers a simple way to implement a fixed iteration:
 
 [[[language=Smalltalk
 n := 1.
 10 timesRepeat: [ n := n*2 ].
-n --> 1024]]]
+n --> 1024
+]]]
 
 We can also send the message ==to:do:== to a number which then acts as the
 initial value of a loop counter. The two arguments are the upper bound, and a
@@ -385,15 +394,18 @@ result := String new.
 result --> '12345678910']]]
 
 ==collect:== builds a new collection of the same size, transforming each
-element.
+element. (You can think of ==collect:== as the Map in the MapReduce
+programming model).
 
 [[[language=Smalltalk
-(1to:10) collect: [ :each | each * each ] --> #(149162536496481100)]]]
+(1 to:10) collect: [ :each | each * each ] --> #(149162536496481100)]]]
 
 ==select:== and ==reject:== build new collections, each containing a subset of
-the elements satisfying (or not) the boolean block condition. detect: returns
-the first element satisfying the condition. Don't forget that strings are also
-collections, so you can iterate over all the characters.
+the elements satisfying (or not) the boolean block condition.
+
+==detect:== returns the first element satisfying the condition. Don't forget
+that strings are also collections (of characters), so you can iterate over all
+the characters.
 
 [[[language=Smalltalk
 'hello there' select: [ :char | char isVowel ] --> 'eoee'
@@ -401,12 +413,13 @@ collections, so you can iterate over all the characters.
 'hello there' detect: [ :char | char isVowel ] --> $e]]]
 
 Finally, you should be aware that collections also support a functional-style
-fold operator in the ==inject:into:== method. This lets you generate a
-cumulative result using an expression that starts with a seed value and injects
-each element of the collection. Sums and products are typical examples.
+fold operator in the ==inject:into:== method. (You can also think of it as the
+Reduce in the MapReduce programming model). This lets you generate a cumulative
+result using an expression that starts with a seed value and injects each
+element of the collection. Sums and products are typical examples.
 
 [[[language=Smalltalk
-(1to:10) inject:0 into: [ :sum :each |sum + each] --> 55]]]
+(1 to: 10) inject: 0 into: [ :sum :each | sum + each] --> 55]]]
 
 This is equivalent to ==0\+\1\+2\+3\+4\+5\+6\+7\+8\+9\+10==.
 
@@ -423,7 +436,7 @@ For example, the following are all implemented as primitives: memory allocation
 pointer and integer arithmetic (\+, \-, \<, \>, \*, \/ , \ , \=, \=\=...), and
 array access (==at:==, ==at:put:==).
 
-Primitives are invoked with the syntax <primitive: aNumber>. A method that
+Primitives are invoked with the syntax ==<primitive: aNumber>==. A method that
 invokes such a primitive may also include Smalltalk code, which will be
 evaluated only if the primitive fails.
 
@@ -443,15 +456,15 @@ In Pharo, the angle bracket syntax is also used for method annotations called
 pragmas.
 
 !!Chapter summary
--Pharo has (only) six reserved identifiers also called pseudo-variables: ==true==, ==false==, ==nil==, ==self==, ==super==, and ==thisContext==.
--There are five kinds of literal objects: numbers (5, 2.5, 1.9e15, 2r111), characters (==$a==), strings (=='hello'==), symbols (==#hello==), and arrays (==#('hello' #hi)==)
+
+-Pharo has only six reserved identifiers (also called pseudo-variables): ==true==, ==false==, ==nil==, ==self==, ==super==, and ==thisContext==.
+-There are five kinds of literal objects: numbers (5, 2.5, 1.9e15, 2r111), characters (==$a==), strings (=='hello'==), symbols (==#hello==), and arrays (==#('hello' #hi)== or =={ 1 . 2 . 1 + 2 }== )
 -Strings are delimited by single quotes, comments by double quotes. To get a quote inside a string, double it.
 -Unlike strings, symbols are guaranteed to be globally unique.
--Use ==#( ... )== to define a literal array. Use =={ ... }== to define a dynamic array.Note that ==#(1\+2) size== \-\-> 3, but ==\{1\+2\} size== \-\-> 1
--There are three kinds of messages: unary (e.g., ==1 asString==, ==Array new==), binary (e.g., ==3 \+ 4==, =='hi' , ' there'==), and keyword (e.g., =='hi' at: 2 put: $o==)
+-Use ==#( ... )== to define a literal array. Use =={ ... }== to define a dynamic array. Note that ==#(1\+2) size== \-\-> 3, but ==\{1\+2\} size== \-\-> 1
+-There are three kinds of messages: unary (e.g., ==1 asString==, ==Array new==), binary (e.g., ==3 \+ 4==, =='hi', ' there'==), and keyword (e.g., =='hi' at: 2 put: $o==)
 -A cascaded message send is a sequence of messages sent to the same target, separated by semi-colons: ==OrderedCollection new add: #calvin; add: #hobbes; size== \-\-> 2
 -Local variables are declared with vertical bars. Use ==:= == for assignment. ==\|x\| x := 1 ==
--Expressions consist of message sends, cascades and assignments, possibly grouped with parentheses. Statements are expressions separated by periods.
--Block closures are expressions enclosed in square brackets. Blocks may take arguments and can contain temporary variables. The expressions in the block are not evaluated until you send the block a value message with the correct number of arguments.[[[
-[ :x | x + 2 ] value: 4 --> 6]]]
+-Expressions consist of message sends, cascades and assignments, evaluated left to right (and optionally grouped with parentheses). Statements are expressions separated by periods.
+-Block closures are expressions enclosed in square brackets. Blocks may take arguments and can contain temporary variables. The expressions in the block are not evaluated until you send the block a value message with the correct number of arguments. ==[ :x | x + 2 ] value: 4 --> 6==
 -There is no dedicated syntax for control constructs, just messages that conditionally evaluate blocks.


### PR DESCRIPTION
Minor syntax / grammar / formatting changes to Syntax in a Nutshell chapter.

Note: does not address issue #6.