### PR TITLE
Replace term 'category' with 'package'

### DIFF
--- a/BasicClasses/BasicClasses.pier
+++ b/BasicClasses/BasicClasses.pier
@@ -20,7 +20,7 @@ hierarchy. Actually, in Pharo the true root of the hierarchy is ==ProtoObject==,
 which is used to define minimal entities that masquerade as objects, but we can
 ignore this point for the time being.
 
-==Object== can be found in the ==Kernel-Objects== category. Astonishingly, there
+==Object== can be found in the ==Kernel-Objects== package. Astonishingly, there
 are some 400 methods to be found here (including extensions).  In other words,
 every class that you define will automatically provide these 400 methods,
 whether you know what they do or not. Note that some of the methods should be
@@ -38,7 +38,7 @@ several classes of objects that inherit from ==Object== that have special
 implementations (==SmallInteger== and ==UndefinedObject== for example) or the VM
 knows about and depends on the structure and layout of certain standard classes.
 
-If we begin to browse the method categories on the instance side of ==Object==
+If we begin to browse the method protocols on the instance side of ==Object==
 we start to see some of the key behaviour it provides.
 
 !!!Printing
@@ -479,7 +479,7 @@ portion of the Smalltalk class hierarchy.
 
 +The Number Hierarchy >file://figures/NumberHierarchy.png|label=fig:numbers+
 
-Numbers are found in the ==Kernel-Numbers== category. The abstract root of this
+Numbers are found in the ==Kernel-Numbers== package. The abstract root of this
 hierarchy is ==Magnitude==, which represents all kinds of classes supporting
 comparision operators. ==Number== adds various arithmetic and other operators as
 mostly abstract methods. ==Float== and ==Fraction== represent, respectively,
@@ -636,7 +636,7 @@ n --> 256
 
 !!Characters
 
-==Character== is defined in the ==Collections-Strings== category as a subclass
+==Character== is defined in the ==Collections-Strings== package as a subclass
 of ==Magnitude==. Printable characters are represented in Pharo as ==$<char>==.
 For example:
 
@@ -693,7 +693,7 @@ Character characterTable size                               --> 256
 
 !!Strings
 
-The ==String== class is also defined in the category ==Collections-Strings==.  A
+The ==String== class is also defined in the package ==Collections-Strings==. A
 ==String== is an indexed ==Collection== that holds only ==Characters==.
 
 +The String Hierarchy >file://figures/StringHierarchy.png|label=fig:strings+

--- a/Collections/Collections.pier
+++ b/Collections/Collections.pier
@@ -16,9 +16,9 @@ class ==Stream== has 50 subclasses, but many of these (like ==Bitmap,==
 use in other parts of the system or in applications, and hence not categorized
 as ''Collections'' by the system organization. For the purposes of this chapter,
 we use the term ''Collection Hierarchy'' to mean ==Collection== and its 47
-subclasses that are ''also'' in the categories labelled ==Collections-*==. We
+subclasses that are ''also'' in the packages labelled ==Collections-*==. We
 use the term ''Stream Hierarchy'' to mean ==Stream== and its 9 subclasses that
-are ''also'' in the ==Collections-Streams== categories. These 56 classes respond
+are ''also'' in the ==Collections-Streams== packages. These 56 classes respond
 to 982 messages and define a total of 1609 methods!
 
 In this chapter we focus mainly on the subset of collection classes shown in

--- a/FirstApplication/FirstApplication.pier
+++ b/FirstApplication/FirstApplication.pier
@@ -28,33 +28,34 @@ you how to define these classes using the Pharo programming tools.
 !!Creating a new Package
 
 We have already seen the browser in Chapter *cha:tour*: A Quick Tour of Pharo,
-where we learned how to navigate
-to classes and methods, and saw how to define new methods. Now we will see how
-to create packages, categories and classes.
+where we learned how to navigate to classes and methods, and saw how to define
+new methods. Now we will see how to create packages and classes.
 
-Type the name of the new package (we will use PBE-LightsOut) in the dialog box
-and click ""accept"" (or just press the return key). The new package is
+Right-click on the Package pane and select ==Add package...== from the menu.
+Type the name of the new package (we will use ==PBE-LightsOut==) in the dialog box
+and click ==OK== (or just press the return key). The new package is
 created, and positioned alphabetically in the list of packages.
 
-!!Defining the class LOCell
+!!Defining the class ==LOCell==
 
 At this point there are of course no classes in the new package. However, the main
 editing pane displays a template to make it easy to create a new class
 
 This template shows us a Smalltalk expression that sends a message to a class
 called ==Object==, asking it to create a subclass called ==NameOfSubClass==. The new
-class has no variables, and should belong to the category ==PBE-LightsOut==.
+class has no variables, and should belong to the category (package) ==PBE-LightsOut==.
 
-!!!On Categories and Packages
+!!!On categories vs. packages
 
-Historically, Smalltalk only knows about categories, not packages. You may well
-ask, what is the difference? A category is simply a collection of related
-classes in a Smalltalk image. A package is a collection of related classes and
-extension methods that may be versioned using the Monticello versioning tool. By
-convention, package names and category names are the same. For most purposes we
-do not care about the difference, but we will be careful to use the correct
-terminology in this book since there are points where the difference is crucial.
-We will learn more when we start working with Monticello.
+Historically, Pharo packages were implemented as "categories". With the newer
+versions of Pharo, the term ""category"" is being deprecated, and replaced
+exclusively by ""package"". However, the method for creating subclasses
+(explained in the next section) still refers to the class's package as
+==category:==. Aside from subclass creation, to maintain consistency, we will
+only use the term ""package"" in this book, to denote a collection or related
+classes (and extension methods to other, existing classes). The Pharo package is
+also what you will be using to version your source code using the Monticello
+versioning tool.
 
 !!!Creating a new class
 
@@ -304,7 +305,7 @@ the top of the browser. In the same way that the first pane of the browser lets
 us categorize classes into packages so we are not overwhelmed by a very long
 list of class names in the class pane, so the protocol pane lets us categorize
 methods so that we are not overwhelmed by a very long list of method names in
-the method pane. These categories of methods are called "protocols".
+the method pane. These groups of methods are called "protocols".
 
 If there are only a few methods in a class, the extra level of hierarchy
 provided by protocols is not really necessary. This is why the browser also
@@ -320,7 +321,7 @@ called ""initialization"".
 
 How does Pharo know that this is the right protocol? Well, in general Pharo
 can't know exactly, but in this case there is also an ==initialize== method in the superclass,
-and Pharo assumes that our ==initialize== method should go in the same category
+and Pharo assumes that our ==initialize== method should go in the same protocol
 as the one that it overrides.
 
 !!!!!A typographic convention. Smalltalkers frequently use the notation ==>>== to
@@ -676,17 +677,17 @@ Pharo and its third party libraries.
 
 !!Chapter summary
 
-In this chapter you have seen how to create categories, classes and methods. In
+In this chapter you have seen how to create packages, classes and methods. In
 addition, you have learned how to use the System browser, the inspector, the debugger and the Monticello
 browser.
 
--Categories are groups of related classes.
+-Packages are groups of related classes.
 -A new class is created by sending a message to its superclass.
--Protocols are groups of related methods.
+-Protocols are groups of related methods inside a class.
 -A new method is created or modified by editing its definition in the browser and then accepting the changes.
 -The inspector offers a simple, general-purpose GUI for inspecting and interacting with arbitrary objects.
 -The browser detects usage of undeclared methods and variables, and offers possible corrections.
 -The ==initialize== method is automatically executed after an object is created in Pharo. You can put any initialization code there.
 -The debugger provides a high-level GUI to inspect and modify the state of a running program.
--You can share source code by filing out a category.
+-You can share source code by filing out a package, class or method.
 -A better way to share code is to use Monticello to manage an external repository, for example defined as a SmalltalkHub project.

--- a/PharoTour/PharoTour.pillar
+++ b/PharoTour/PharoTour.pillar
@@ -399,7 +399,7 @@ shared by all objects in the system (except those that override it).
 !!Finding classes
 
 There are several ways to find a class in Pharo. The first, as we have just
-seen above, is to know (or guess) what category it is in, and to navigate to it
+seen above, is to know (or guess) what package it is in, and to navigate to it
 using the browser.
 
 A second way is to send the ""browse"" message to the class, asking it to open a
@@ -423,7 +423,7 @@ This is nothing more than an ordinary message that is sent to the parent class,
 asking it to create a subclass. Here we see that the class Object is being asked
 to create a subclass named Boolean with no instance variables, class variables
 or ''pool dictionaries'', and to put the class Boolean in the Kernel-Objects
-category. If you click on the ""comments"" button at the bottom of the class
+package. If you click on the ""comments"" button at the bottom of the class
 pane, you can see the class comment in a dedicated pane.
 
 +The Boolean class with the comments section>file://figures/Boolean.png|width=100|label=boolean+
@@ -590,11 +590,11 @@ the first option from the menu of choices.
 Run your newly created test: open the ""Test Runner"" from the World Menu.
 
 The leftmost two panes are a bit like the top panes in the System Browser. The
-left pane contains a list of categories, but it's restricted to those categories
+left pane contains a list of packages, but it's restricted to those packages
 that contain test classes.
 
 Select ""CollectionsTests-Strings"", and the pane to the right will show all of
-the test classes in that category, which includes the class ""StringTest"". The
+the test classes in that package, which includes the class ""StringTest"". The
 names of the classes are already selected, so click Run Selected to run all
 these tests.
 

--- a/Reflection/Reflection.pier
+++ b/Reflection/Reflection.pier
@@ -557,7 +557,7 @@ OrderedCollection>>>add: newObject
 ]]]
 
 This time the image does not freeze. Try running the ==OrderedCollectionTest==.
-(You can find it in the ==CollectionsTests-Sequenceable== category.)
+(You can find it in the ==CollectionsTests-Sequenceable== package.)
 
 How does this work?  Let's have a look at ==Object>>haltIf:==:
 

--- a/SUnit/SUnit.pillar
+++ b/SUnit/SUnit.pillar
@@ -247,8 +247,8 @@ of the results using the SUnit Test Runner, which you can open by selecting
 The ''TestRunner'', shown in *test-runner*, is designed to make it easy to
 execute groups of tests.
 
-The left-most pane lists all of the categories that contain test classes (i.e.,
-subclasses of ==TestCase==; when some of these categories are selected, the test
+The left-most pane lists all of the packages that contain test classes (i.e.,
+subclasses of ==TestCase==; when some of these packages are selected, the test
 classes that they contain appear in the pane to the right. Abstract classes are
 italicized, and the test class hierarchy is shown by indentation, so subclasses
 of ==ClassTestCase== are indented more than subclasses of ==TestCase==.

--- a/Seaside/Seaside.pier
+++ b/Seaside/Seaside.pier
@@ -546,7 +546,7 @@ field.
 The same message is used twice more in this example, to cause the selection of a
 colour on the html form to update the ==color== variable, and to bind the result
 of the checkbox to the ==checked== variable. Many other examples can be found in
-the functional tests for Seaside. Have a look at the category
+the functional tests for Seaside. Have a look at the package
 ==Seaside-Tests-Functional==, or just point your browser to
 *http://localhost:8080/seaside/tests/alltests*. Select ==WAInputTest== and click
 on the ==Restart== button to see most of the features of forms.
@@ -783,7 +783,7 @@ A task is a component that subclasses ==WATask==. It does not render anything
 itself, but simply calls other components in a control flow defined by
 implementing the method ==go==.
 
-==WAConvenienceTest== is a simple example of a task defined in the category
+==WAConvenienceTest== is a simple example of a task defined in the package
 ==Seaside-Tests-Functional==. To see its effect, just point your browser to
 *http://localhost:8080/seaside/tests/alltests*, select ==WAConvenienceTest== and
 click ==Restart==.
@@ -1013,7 +1013,7 @@ button to call another component to display the detailed view.
 provides a button to answer back. It is a subclass of ==MyDisplay==.
 
 
-@@todo Define ==MyRPNWidget== in the category ==MyCalculator==.
+@@todo Define ==MyRPNWidget== in the package ==MyCalculator==.
 
 Define the common ==style== for the application.
 

--- a/SmalltalkObjectModel/SmalltalkObjectModel.pier
+++ b/SmalltalkObjectModel/SmalltalkObjectModel.pier
@@ -495,7 +495,7 @@ Trait named: #TAuthor
     category: 'PBE-LightsOut'
 ]]]
 
-Here we define the trait ==TAuthor== in the category ==PBE-LightsOut==.This
+Here we define the trait ==TAuthor== in the package ==PBE-LightsOut==.This
 trait does not ''use'' any other existing traits.In general we can specify a
 ''trait composition expression'' of other traits to use as part of the ==uses:==
 keyword argument. Here we simply provide an empty array.


### PR DESCRIPTION
* Edited 'Creating a new Package' section in FirstApplication to simply use 'Add package...' menu item
* Added an explanation that the term 'package' is replacing the older term 'category' (per Stef's suggestion),
    but also that the subclass creation method still refers to `category:` to denote which package a class belongs to
* Replaced all appropriate references to 'category' with 'package'.
* Also replaced references to 'categories' when they meant 'protocols'.
Addresses issue #25