### PR TITLE
FirstApplication - remove 'efficient' sentence.

### DIFF
--- a/FirstApplication/FirstApplication.pier
+++ b/FirstApplication/FirstApplication.pier
@@ -6,11 +6,7 @@ Out>http://en.wikipedia.org/wiki/Lights_Out_(game)*. Along the way we will
 demonstrate most of the tools that Pharo programmers use to construct and debug
 their programs, and show how programs are exchanged with other developers. We
 will see the browser, the object inspector, the debugger and the Monticello
-package browser. Development in Smalltalk is efficient: you will find that you
-spend far more time actually writing code and far less managing the development
-process. This is partly because the Smalltalk language is very simple, and
-partly because the tools that make up the programming environment are very well
-integrated with the language.
+package browser.
 
 !!The Lights Out game
 


### PR DESCRIPTION
Proposing to remove the `Development in smalltalk is efficient` /
You will spend "far less managing the development process" copy:

1. It's best to surprise and delight the user (with the efficiency)
    rather than inflate their expectations

2. When learning new systems, nothing seems efficient (even if it is),
    so best not remind readers of it.