### PR TITLE
Rearranged sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,46 +21,39 @@
 <!-- --- NEWS -------------------------------------------------- -->
 <h1>News</h1>
 <p><b>2013-10-01</b>: Pharo by Example 2, AKA <a href="http://www.deepintopharo.com/">Deep into Pharo</a>, is now available.</p>
-<p><b>2013-05-12</b>: A <a href="es/PBE1-sp.pdf">Spanish translation</a> is available.</p>
-<p><b>2013-04-23</b>: A <a href="https://github.com/SquareBracketAssociates/PharoByExample-japanese/wiki/Pharo-by-Example-%28ja%29">Japanese translation</a> is now available.</p>
-<p><b>2012-03-28</b>: <a href="http://rmod.lille.inria.fr/pbe2/">Pharo by Example 2</a> has its own web site</p>
-<p><b>2011-07-27</b>: The <a href="fr/index.html">French translation</a> of Pharo by Example is online!</p>
-<p><b>2011-04-06</b>: The draft chapter on <a href="drafts/Metacello.pdf">Metacello</a> for <em>Pharo by Example 2</em> is available for review!</p>
-<!-- --- TRANSLATIONS -------------------------------------------------- -->
-<h1>Translations</h1>
-<p>Help is welcome for the following translation projects:</p>
+<!-- --- DOWNLOAD -------------------------------------------------- -->
+<h1>Download</h1>
+<ul>
+	<li><a href="https://ci.inria.fr/pharo-contribution/view/Books/job/UpdatedPharoByExample/lastSuccessfulBuild/artifact/book-result/UpdatedPharoByExample.pdf">Latest UPBE book</a></li>
+	<li><a href="https://github.com/bencoman/UpdatedPharoByExample/releases/download/Test/PBE-pharo4.zip">Pharo 4 platform for UPBE</a> (image and VMs for use with book)  </li> 
+	<li><a target=blank_ href="http://www.pharo.org/download">Latest Pharo platform</a></li>
+</ul>
+<!-- --- TRANSLATIONS  -------------------------------------------------- -->
+<h1>Translations (todo) </h1>
+<p>Help is welcome for the following translation projects </p>
 <ul>
 <li><a href="fr/index.html">French translation</a> &mdash; contact: <a href="mailto:Serge.Stinckwich@gmail.com">Serge.Stinckwich@gmail.com</a></li>
 <li>Spanish translation &mdash; contact: <a href="mailto:nicopaez@gmail.com">nicopaez@gmail.com</a></li>
 </ul>
 
 <!-- --- RESOURCES -------------------------------------------------- -->
-<h1>Resources</h1>
+<h1>Resources (todo) </h1>
 <ul>
-<li><a target=_blank href="http://www.lulu.com/content/paperback-book/pharo-by-example/7522128">Buy the book!</a> (lulu.com)</li>
-<li><a target=blank_ href="versions/PBE1-2009-10-28.pdf">Download latest version</a>
-	<br/>(352 pp., 9.4MB pdf)</li>
-<li><a href="http://www.deepintopharo.com/">Deep into Pharo</a> (PBE 2)</li>	
-<li><a target=blank_ href="http://scg.unibe.ch/download/pharobyexample/">Browse old versions</a></li>
+<li>Buy the book! (lulu.com again?)</li>
+<li><a href="https://ci.inria.fr/pharo-contribution/view/Books/job/UpdatedPharoByExample/">Continuous integration artifacts</a></li>
+<li><a href="https://github.com/SquareBracketAssociates/UpdatedPharoByExample">UPBE sources</a> (please contribute) </li>
+<li><a target=blank_ href="http://pharo.scg.unibe.ch/download/pharobyexample/">Browse old Pharo 1.1 PBE </a></li>
 <li><a target=blank_ href="http://creativecommons.org/licenses/by-sa/3.0/">Creative commons by-sa license</a></li>
-<li><a target=_blank href="http://www.pharocasts.com/2010/11/lightsout-game.html">Screencast of the Lights Out exercise</a></li>
-<li><a target=blank_ href="http://www.squeaksource.com/PharoByExample.html">Source code</a> (SqueakSource)</li>
-<li><a href="https://github.com/SquareBracketAssociates/PharoByExample-english/blob/master/pbe1-examples.txt">Code snippets</a> from the book to copy/paste</li>
-<li><a target=blank_ href="http://github.com/SquareBracketAssociates/PharoByExample-english/blob/master/errata.txt">errata</a></li>
-<li><a href="http://github.com/SquareBracketAssociates/">LaTeX sources</a> (github)</li>
-<li><a target=blank_ href="http://scg.unibe.ch/scgbib?query=Blac09a&display=bibtex">bibtex reference</a></li>
+<li><a target=_blank href="http://www.pharocasts.com/2010/11/lightsout-game.html">Screencast of the Lights Out exercise</a> (todo)</li>
+<li><a target=blank_ href="http://www.squeaksource.com/PharoByExample.html">Source code</a> (SqueakSource)(todo) </li>
+<li><a href="https://github.com/SquareBracketAssociates/PharoByExample-english/blob/master/pbe1-examples.txt">Code snippets</a> from the book to copy/paste (todo) </li>
+<li><a target=blank_ href="http://github.com/SquareBracketAssociates/PharoByExample-english/blob/master/errata.txt">errata</a> (todo) </li>
+<li><a target=blank_ href="http://scg.unibe.ch/scgbib?query=Blac09a&display=bibtex">Bibtex reference (todo) </a></li>
 <li><a target=blank_ href="https://www.iam.unibe.ch/mailman/listinfo/sbe-discussion">Discussion list</a> and <a target=blank_ href="http://www.iam.unibe.ch/pipermail/sbe-discussion/">archive</a></li>
 </ul>
 <!-- p>PDF downloads to date: <img src="http://www.iam.unibe.ch/server-cntr/~scg/SBE/SBE.pdf?face=sgrey"></p> -->
-<!-- --- EXTERNAL -------------------------------------------------- -->
-<h1>Download Pharo</h1>
-<ul>
-	<!-- <li><a href="http://scg.unibe.ch/download/pharobyexample/PBE.zip">Pharo By Example image</a> (recommended for use with the book)</li> -->
-	<li><a href="image/PBE-OneClick-1.1.app.zip">Pharo By Example image</a> (recommended for use with the book)</li>
-	<li><a target=blank_ href="http://www.pharo-project.org/">Pharo download</a> (VM, sources and various images)</li>
-</ul>
 <!-- --- AUTHORS -------------------------------------------------- -->
-<h1>Authors</h1>
+<h1>Authors (todo)</h1>
 <ul>
 	<li><a target=blank_ href="http://web.cecs.pdx.edu/~black/">Andrew P. Black</a></li>
 	<li><a target=blank_ href="http://stephane.ducasse.free.fr/">St&eacute;phane Ducasse</a></li>
@@ -72,11 +65,12 @@
 <!-- --- EXTERNAL -------------------------------------------------- -->
 <h1>External resources</h1>
 <ul>
+<li><a href="http://www.deepintopharo.com/">Deep into Pharo</a> (PBE 2)</li>	
 <li><a target=blank_ href="http://en.wikipedia.org/wiki/Pharo">Pharo on Wikipedia</a></li>
 <li><a target=blank_ href="http://lists.gforge.inria.fr/mailman/listinfo/pharo-project">Pharo mailing list</a></li>
-<li><a target=blank_ href="http://stephane.ducasse.free.fr/FreeBooks.html">free books on Smalltalk</a></li>
+<li><a target=blank_ href="http://stephane.ducasse.free.fr/FreeBooks.html">Free books on Smalltalk</a></li>
 <li><a target=blank_ href="http://stephane.ducasse.free.fr/Videos/2008-SmalltalkVideos/">Smalltalk Videos</a></li>
-<li><a target=blank_ href="https://www.iam.unibe.ch/scg/svn_repos/Lectures/Smalltalk/">open source lecture slides</a> (ppt)</li>
+<li><a target=blank_ href="https://www.iam.unibe.ch/scg/svn_repos/Lectures/Smalltalk/">Open source lecture slides</a> (ppt)</li>
 </ul>
 <p>Endorsed by <a target=blank_ href="http://www.esug.org"><img src="pictures/esug-logo.png" width=50% border=0></a></p>
 </div>


### PR DESCRIPTION
What is the release strategy for updating http://pharobyexample.org/ when UPBE is released ?  

To help keep the website and book in sync, it might be nice for the website to be included in the book repository as described... 
https://pages.github.com/
https://help.github.com/articles/user-organization-and-project-pages/
https://help.github.com/articles/creating-project-pages-manually/
https://help.github.com/articles/about-custom-domains-for-github-pages-sites/

As proof of concept I scraped the original website into an orphan gh-pages branch, then pushed that to SquareBracketsAssociates -- to give something to compare this PR against. This can be viewed at...
http://squarebracketassociates.github.io/UpdatedPharoByExample/
until a custom domain is assigned.

The result of changes for this PR can be reviewed at...
http://bencoman.github.io/UpdatedPharoByExample/
which rearranged the sidebar a bit, mainly moving the Download section to the top and updating some links.

 cheers -ben