### PR TITLE
Clarify steps to add a package

### DIFF
--- a/FirstApplication/FirstApplication.pier
+++ b/FirstApplication/FirstApplication.pier
@@ -31,11 +31,12 @@ We have already seen the browser in Chapter
 learned how to navigate to classes and methods, and saw how to define new
 methods. Now we will see how to create packages and classes.
 
-Right-click on the Package pane and select ==Add package...== from the menu
-(see Figure *@fig:createPackage*). Type the name of the new package (we will use
-==PBE-LightsOut==) in the dialog box and click ==OK== (or just press the return
-key). The new package is created, and positioned alphabetically in the list of
-packages.
+From the ==World== menu, open a System Browser. Right-click on an existing
+package in the Package pane and select ==Add package...== from the menu
+(see Figure *@fig:createPackage*). Type the name of the new package (we
+will use ==PBE-LightsOut==) in the dialog box and click ==OK== (or just
+press the return key). The new package is created, and positioned
+alphabetically in the list of packages.
 
 !!Defining the class ==LOCell==
 


### PR DESCRIPTION
Right-clicking on a non-package in the Package pane doesn't give the option to add a package, so added clarifying detail to this step.