### PR TITLE
Do not reference link to get invited on slack but link to pharo website

### DIFF
--- a/Preface/Preface.pillar
+++ b/Preface/Preface.pillar
@@ -81,7 +81,7 @@ that you may find useful:
 - *http://www.pharo.org>http://www.pharo.org* is the main web site of Pharo.
 - On IRC, you can find us on the freenode.net server, channel "pharo".
 - SmalltalkHub (*http://www.smalltalkhub.com/>http://www.smalltalkhub.com/*) is the equivalent of SourceForge/Github for Pharo projects. Many extra packages and projects for Pharo live there.
-- Pharo is also active on Slack - a platform for chat based on IRC (*http://pharoproject.slack.com*), just ask for an invitation at *http://slackinvites.pharo.org*. Everybody is welcomed.
+- Pharo is also active on Slack - a platform for chat based on IRC (*http://pharoproject.slack.com*), just ask for an invitation on Pharo's website *http://pharo.org/community*, in the slack section. Everybody is welcomed.
 
 !!Examples and exercises
 


### PR DESCRIPTION
The link to get invited on Pharo's slack changed. To avoir changing it all the time I propose to link to Pharo's website. Thus the book will always be right and we only need to update the website.